### PR TITLE
TKE-7: compile first cluster docs batch

### DIFF
--- a/src/content/docs/basics/cluster/01-create-cluster.md
+++ b/src/content/docs/basics/cluster/01-create-cluster.md
@@ -303,7 +303,7 @@ kubectl get nodes
 
 **期望结果**:
 
-```
+```text
 Kubernetes control plane is running at https://cls-xxxxxxxx.ccs.tencent-cloud.com
 CoreDNS is running at https://cls-xxxxxxxx.ccs.tencent-cloud.com/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
 ```
@@ -435,7 +435,7 @@ tccli tke EnableClusterDeletionProtection \
 ## 相关文档
 
 - [删除集群](./02-delete-cluster.md)
-- 查询集群列表
+- [查询集群列表](./04-describe-clusters.md)
 - [添加节点到集群](../node/01-add-node.md)
 - 配置集群访问凭证
 
@@ -451,7 +451,7 @@ tccli tke EnableClusterDeletionProtection \
 
 ## Cookbook 示例
 
-完整可执行代码示例: TKE 集群创建 Cookbook
+完整可执行代码示例: [TKE 集群创建 Cookbook](/cookbooks/create-cluster/)；源码见 [`cookbook/cluster/create_cluster.py`](https://github.com/tke-workshop/tke-workshop.github.io/blob/main/cookbook/cluster/create_cluster.py)。
 
 ---
 

--- a/src/content/docs/basics/cluster/02-delete-cluster.md
+++ b/src/content/docs/basics/cluster/02-delete-cluster.md
@@ -349,7 +349,9 @@ tccli cbs CreateSnapshot \
   --SnapshotName "backup-before-delete"
 
 # 方式2: 复制数据到对象存储
-kubectl exec -n <namespace> <pod-name> -- tar czf - /data | \
+NAMESPACE="<namespace>"
+POD_NAME="<pod-name>"
+kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -- tar czf - /data | \
   coscli cp - cos://bucket/backup/data.tar.gz
 ```
 
@@ -406,7 +408,7 @@ kubectl exec -n <namespace> <pod-name> -- tar czf - /data | \
 ## 相关文档
 
 - [创建集群](./01-create-cluster.md)
-- 查询集群列表
+- [查询集群列表](./04-describe-clusters.md)
 - 启用删除保护
 - 集群备份与恢复
 


### PR DESCRIPTION
## Doc Compile Report

Scope:
- `src/content/docs/basics/cluster/01-create-cluster.md`
- `src/content/docs/basics/cluster/02-delete-cluster.md`
- `src/content/docs/basics/cluster/04-describe-clusters.md`
- Direct references: `cookbook/cluster/create_cluster.py`, `cookbook/common/*.py`, `cookbook/config.example.yaml`, `src/data/navigation.mjs`, `src/data/cookbooks.js`, `test/*.mjs`

Auto-fixes:
- Added missing code fence language for create-cluster expected output.
- Linked cluster related-doc references to the scoped query doc.
- Linked the existing create-cluster cookbook page and source file.
- Made the delete doc COS backup snippet shell-parseable by replacing raw angle-bracket placeholders with explicit variables.

Verification:
- `node --test test/navigation.test.mjs test/cookbooks.test.mjs`
- `python3 -m py_compile cookbook/**/*.py`
- scoped markdown fence/relative-link checker for the three cluster docs
- `git diff --check`
- `npm run build`

Skipped:
- `mkdocs build --strict`: repo has no MkDocs config and `mkdocs` is not installed in this checkout.

Follow-up:
- Created backlog doc-improvement issue TKE-8 for missing delete/describe cluster cookbook examples.
- Real Tencent Cloud/TKE execution was not performed; these docs still require Live Verify.

Closes TKE-7
