### PR TITLE
TKE-9: 修正 CreateCluster AutoUpgradeClusterLevel 示例

### DIFF
--- a/cookbook/cluster/create_cluster.py
+++ b/cookbook/cluster/create_cluster.py
@@ -8,6 +8,7 @@
 """
 
 import argparse
+import json
 import sys
 import time
 from pathlib import Path
@@ -21,6 +22,53 @@ from tencentcloud.tke.v20180525 import models
 from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentCloudSDKException
 
 logger = setup_logger(__name__)
+
+
+def build_create_cluster_request(
+    cluster_name: str,
+    k8s_version: str,
+    vpc_id: str,
+    cluster_cidr: str,
+    service_cidr: str,
+    cluster_level: str
+):
+    """
+    构造 CreateCluster 请求。
+    """
+    req = models.CreateClusterRequest()
+    req.ClusterType = "MANAGED_CLUSTER"
+
+    # 集群基础配置
+    req.ClusterBasicSettings = models.ClusterBasicSettings()
+    req.ClusterBasicSettings.ClusterName = cluster_name
+    req.ClusterBasicSettings.ClusterVersion = k8s_version
+    req.ClusterBasicSettings.VpcId = vpc_id
+    req.ClusterBasicSettings.ClusterLevel = cluster_level
+    req.ClusterBasicSettings.AutoUpgradeClusterLevel = models.AutoUpgradeClusterLevel()
+    req.ClusterBasicSettings.AutoUpgradeClusterLevel.IsAutoUpgrade = True
+
+    # 网络配置
+    req.ClusterCIDRSettings = models.ClusterCIDRSettings()
+    req.ClusterCIDRSettings.ClusterCIDR = cluster_cidr
+    req.ClusterCIDRSettings.MaxNodePodNum = 64
+    req.ClusterCIDRSettings.ServiceCIDR = service_cidr
+
+    return req
+
+
+def resolve_vpc_id(vpc_id: str = None) -> str:
+    """
+    解析 VPC ID。
+    """
+    if vpc_id:
+        return vpc_id
+
+    config = load_config()
+    vpc_id = config.get('cluster', {}).get('vpc_id')
+    if not vpc_id or vpc_id == 'vpc-xxxxxxxx':
+        raise ValueError("请在 config.yaml 中配置 vpc_id 或通过 --vpc-id 参数指定")
+
+    return vpc_id
 
 
 def create_cluster(
@@ -48,35 +96,19 @@ def create_cluster(
         集群 ID
     """
     with LogContext(logger, f"创建集群: {cluster_name}"):
-        # 加载配置
-        config = load_config()
-        if not vpc_id:
-            vpc_id = config.get('cluster', {}).get('vpc_id')
-            if not vpc_id or vpc_id == 'vpc-xxxxxxxx':
-                raise ValueError("请在 config.yaml 中配置 vpc_id 或通过 --vpc-id 参数指定")
-        
+        vpc_id = resolve_vpc_id(vpc_id)
+
         # 创建客户端
         client = get_tke_client(region)
-        
-        # 构造请求
-        req = models.CreateClusterRequest()
-        req.ClusterType = "MANAGED_CLUSTER"
-        
-        # 集群基础配置
-        req.ClusterBasicSettings = models.ClusterBasicSettings()
-        req.ClusterBasicSettings.ClusterName = cluster_name
-        req.ClusterBasicSettings.ClusterVersion = k8s_version
-        req.ClusterBasicSettings.VpcId = vpc_id
-        req.ClusterBasicSettings.ClusterLevel = cluster_level
-        req.ClusterBasicSettings.AutoUpgradeClusterLevel = True
-        
-        # 网络配置
-        req.ClusterCIDRSettings = models.ClusterCIDRSettings()
-        req.ClusterCIDRSettings.ClusterCIDR = cluster_cidr
-        req.ClusterCIDRSettings.MaxNodePodNum = 64
-        req.ClusterCIDRSettings.ServiceCIDR = service_cidr
-        req.ClusterCIDRSettings.VpcId = vpc_id
-        req.ClusterCIDRSettings.CniType = "vpc-cni"
+
+        req = build_create_cluster_request(
+            cluster_name=cluster_name,
+            k8s_version=k8s_version,
+            vpc_id=vpc_id,
+            cluster_cidr=cluster_cidr,
+            service_cidr=service_cidr,
+            cluster_level=cluster_level
+        )
         
         try:
             # 发起请求
@@ -174,12 +206,27 @@ def main():
     parser.add_argument('--cluster-level', default='L5', 
                        choices=['L5', 'L20', 'L50', 'L100', 'L200'],
                        help='集群规模')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='只构造并序列化 CreateCluster 请求,不调用腾讯云 API')
     parser.add_argument('--wait', action='store_true', help='等待集群就绪')
     parser.add_argument('--timeout', type=int, default=1800, help='等待超时时间(秒)')
     
     args = parser.parse_args()
     
     try:
+        if args.dry_run:
+            vpc_id = resolve_vpc_id(args.vpc_id)
+            req = build_create_cluster_request(
+                cluster_name=args.cluster_name,
+                k8s_version=args.k8s_version,
+                vpc_id=vpc_id,
+                cluster_cidr=args.cluster_cidr,
+                service_cidr=args.service_cidr,
+                cluster_level=args.cluster_level
+            )
+            print(json.dumps(req._serialize(), ensure_ascii=False, indent=2))
+            sys.exit(0)
+
         # 创建集群
         cluster_id = create_cluster(
             cluster_name=args.cluster_name,

--- a/src/content/docs/basics/cluster/01-create-cluster.md
+++ b/src/content/docs/basics/cluster/01-create-cluster.md
@@ -9,7 +9,7 @@ title: "如何创建 TKE 集群"
 - **功能名称**: 创建 TKE 集群
 - **API 版本**: 2018-05-25
 - **适用集群版本**: 所有版本
-- **文档更新时间**: 2026-01-07
+- **文档更新时间**: 2026-06-16
 - **Agent 友好度**: ⭐⭐⭐⭐⭐
 
 ---
@@ -58,9 +58,7 @@ title: "如何创建 TKE 集群"
   "ClusterCIDR": "172.16.0.0/16",        // 集群容器网络 CIDR
   "MaxNodePodNum": 64,                    // 每个节点最大 Pod 数
   "MaxClusterServiceNum": 256,            // 集群最大 Service 数
-  "ServiceCIDR": "10.96.0.0/16",         // Service CIDR
-  "VpcId": "vpc-xxxxxxxx",                // VPC ID (必填)
-  "CniType": "vpc-cni"                    // CNI 类型: vpc-cni 或 gre
+  "ServiceCIDR": "10.96.0.0/16"          // Service CIDR
 }
 ```
 
@@ -74,7 +72,9 @@ title: "如何创建 TKE 集群"
   "VpcId": "vpc-xxxxxxxx",                // VPC ID
   "ProjectId": 0,                         // 项目ID (默认0)
   "ClusterLevel": "L5",                   // 集群规模: L5/L20/L50/L100/L200/L500
-  "AutoUpgradeClusterLevel": true         // 是否自动升配
+  "AutoUpgradeClusterLevel": {            // 集群规格自动升配配置
+    "IsAutoUpgrade": true                 // 是否自动升配
+  }
 }
 ```
 
@@ -100,19 +100,22 @@ curl -X POST "https://tke.tencentcloudapi.com/" \
       "ClusterName": "my-tke-cluster",
       "ClusterVersion": "1.28.3",
       "VpcId": "vpc-xxxxxxxx",
-      "ClusterLevel": "L5"
+      "ClusterLevel": "L5",
+      "AutoUpgradeClusterLevel": {
+        "IsAutoUpgrade": true
+      }
     },
     "ClusterCIDRSettings": {
       "ClusterCIDR": "172.16.0.0/16",
       "MaxNodePodNum": 64,
-      "ServiceCIDR": "10.96.0.0/16",
-      "VpcId": "vpc-xxxxxxxx",
-      "CniType": "vpc-cni"
+      "ServiceCIDR": "10.96.0.0/16"
     }
   }'
 ```
 
 **注意**: 腾讯云 API 需要 TC3-HMAC-SHA256 签名算法,建议使用 SDK 或 tccli 工具简化调用。签名算法详见: https://cloud.tencent.com/document/api/457/31853
+
+Live Verify 会在执行层为创建类请求注入 `billing:virgilliang` 治理标签；普通读者不需要在下方示例中手工照抄该标签。
 
 **使用腾讯云 CLI (tccli)**:
 
@@ -124,14 +127,15 @@ tccli tke CreateCluster \
     "ClusterName": "my-tke-cluster",
     "ClusterVersion": "1.28.3",
     "VpcId": "vpc-xxxxxxxx",
-    "ClusterLevel": "L5"
+    "ClusterLevel": "L5",
+    "AutoUpgradeClusterLevel": {
+      "IsAutoUpgrade": true
+    }
   }' \
   --ClusterCIDRSettings '{
     "ClusterCIDR": "172.16.0.0/16",
     "MaxNodePodNum": 64,
-    "ServiceCIDR": "10.96.0.0/16",
-    "VpcId": "vpc-xxxxxxxx",
-    "CniType": "vpc-cni"
+    "ServiceCIDR": "10.96.0.0/16"
   }'
 ```
 
@@ -155,14 +159,14 @@ req.ClusterBasicSettings.ClusterName = "my-tke-cluster"
 req.ClusterBasicSettings.ClusterVersion = "1.28.3"
 req.ClusterBasicSettings.VpcId = "vpc-xxxxxxxx"
 req.ClusterBasicSettings.ClusterLevel = "L5"
+req.ClusterBasicSettings.AutoUpgradeClusterLevel = models.AutoUpgradeClusterLevel()
+req.ClusterBasicSettings.AutoUpgradeClusterLevel.IsAutoUpgrade = True
 
 # 网络配置
 req.ClusterCIDRSettings = models.ClusterCIDRSettings()
 req.ClusterCIDRSettings.ClusterCIDR = "172.16.0.0/16"
 req.ClusterCIDRSettings.MaxNodePodNum = 64
 req.ClusterCIDRSettings.ServiceCIDR = "10.96.0.0/16"
-req.ClusterCIDRSettings.VpcId = "vpc-xxxxxxxx"
-req.ClusterCIDRSettings.CniType = "vpc-cni"
 
 # 发起请求
 resp = client.CreateCluster(req)
@@ -194,14 +198,15 @@ func main() {
 		ClusterVersion: common.StringPtr("1.28.3"),
 		VpcId:          common.StringPtr("vpc-xxxxxxxx"),
 		ClusterLevel:   common.StringPtr("L5"),
+		AutoUpgradeClusterLevel: &tke.AutoUpgradeClusterLevel{
+			IsAutoUpgrade: common.BoolPtr(true),
+		},
 	}
 	
 	request.ClusterCIDRSettings = &tke.ClusterCIDRSettings{
 		ClusterCIDR:           common.StringPtr("172.16.0.0/16"),
 		MaxNodePodNum:         common.Uint64Ptr(64),
 		ServiceCIDR:           common.StringPtr("10.96.0.0/16"),
-		VpcId:                 common.StringPtr("vpc-xxxxxxxx"),
-		CniType:               common.StringPtr("vpc-cni"),
 	}
 
 	response, err := client.CreateCluster(request)
@@ -368,10 +373,14 @@ CoreDNS is running at https://cls-xxxxxxxx.ccs.tencent-cloud.com/api/v1/namespac
 ```json
 {
   "ClusterBasicSettings": {
-    "AutoUpgradeClusterLevel": true
+    "AutoUpgradeClusterLevel": {
+      "IsAutoUpgrade": true
+    }
   }
 }
 ```
+
+`AutoUpgradeClusterLevel` 是对象类型,不是布尔值；当前 CreateCluster API 示例使用 `{"IsAutoUpgrade": true}`。
 
 ### 配置集群删除保护
 
@@ -453,8 +462,18 @@ tccli tke EnableClusterDeletionProtection \
 
 完整可执行代码示例: [TKE 集群创建 Cookbook](/cookbooks/create-cluster/)；源码见 [`cookbook/cluster/create_cluster.py`](https://github.com/tke-workshop/tke-workshop.github.io/blob/main/cookbook/cluster/create_cluster.py)。
 
+执行真实创建前,可先运行 dry-run 校验 SDK 请求结构:
+
+```bash
+python3 cookbook/cluster/create_cluster.py \
+  --cluster-name my-tke-cluster \
+  --region ap-guangzhou \
+  --vpc-id vpc-xxxxxxxx \
+  --dry-run
+```
+
 ---
 
-**文档版本**: v1.0  
-**最后更新**: 2026-01-07  
+**文档版本**: v1.0<br>
+**最后更新**: 2026-06-16<br>
 **维护者**: TKE Documentation Team

--- a/test/create-cluster-autoupgrade.test.mjs
+++ b/test/create-cluster-autoupgrade.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const cookbookSource = readFileSync('cookbook/cluster/create_cluster.py', 'utf8');
+const createClusterDoc = readFileSync(
+  'src/content/docs/basics/cluster/01-create-cluster.md',
+  'utf8'
+);
+
+test('create cluster cookbook uses SDK object for AutoUpgradeClusterLevel', () => {
+  assert.doesNotMatch(
+    cookbookSource,
+    /AutoUpgradeClusterLevel\s*=\s*True/,
+    'AutoUpgradeClusterLevel must not be sent as a boolean'
+  );
+  assert.match(
+    cookbookSource,
+    /AutoUpgradeClusterLevel\s*=\s*models\.AutoUpgradeClusterLevel\(\)/,
+    'AutoUpgradeClusterLevel should use the Tencent Cloud SDK model object'
+  );
+  assert.match(
+    cookbookSource,
+    /AutoUpgradeClusterLevel\.IsAutoUpgrade\s*=\s*True/,
+    'AutoUpgradeClusterLevel.IsAutoUpgrade should enable automatic cluster level upgrade'
+  );
+  assert.match(
+    cookbookSource,
+    /--dry-run/,
+    'cookbook should expose a non-destructive dry-run mode'
+  );
+  assert.match(
+    cookbookSource,
+    /req\._serialize\(\)/,
+    'dry-run should serialize the SDK request so model/type regressions are visible'
+  );
+  assert.doesNotMatch(
+    cookbookSource,
+    /ClusterCIDRSettings\.(VpcId|CniType)\s*=/,
+    'cookbook should not assign fields that are absent from the ClusterCIDRSettings SDK model'
+  );
+});
+
+test('create cluster documentation shows AutoUpgradeClusterLevel as an object', () => {
+  assert.doesNotMatch(
+    createClusterDoc,
+    /"AutoUpgradeClusterLevel"\s*:\s*true/,
+    'documentation must not show AutoUpgradeClusterLevel as a JSON boolean'
+  );
+  assert.match(
+    createClusterDoc,
+    /"AutoUpgradeClusterLevel":\s*\{\s*"IsAutoUpgrade": true\s*\}/s,
+    'documentation should show AutoUpgradeClusterLevel.IsAutoUpgrade'
+  );
+});


### PR DESCRIPTION
## Doc Improvement Report

来源 issue: TKE-9

修改范围:
- `src/content/docs/basics/cluster/01-create-cluster.md`
- `cookbook/cluster/create_cluster.py`
- `test/create-cluster-autoupgrade.test.mjs`

变更内容:
- 按腾讯云 CreateCluster API 文档将 `ClusterBasicSettings.AutoUpgradeClusterLevel` 从 boolean 修正为对象结构 `{ "IsAutoUpgrade": true }`。
- 同步更新 API、tccli、Python SDK、Go SDK 示例。
- cookbook 改为使用 `models.AutoUpgradeClusterLevel()` 并设置 `IsAutoUpgrade = True`。
- 新增 `--dry-run`，仅构造并序列化 SDK 请求，不调用腾讯云 API，便于发现 SDK model 与文档示例参数类型不一致。
- dry-run 过程中发现并移除了 cookbook/示例里不属于 `ClusterCIDRSettings` SDK model 的 `VpcId`、`CniType` 字段；`VpcId` 保留在 `ClusterBasicSettings`。
- 补充说明 Live Verify 的 `billing:virgilliang` 治理标签由执行层注入，普通读者不需要照抄。

验证命令:
- `uv run --with-requirements cookbook/requirements.txt python cookbook/cluster/create_cluster.py --cluster-name doc-audit-test --region ap-guangzhou --vpc-id vpc-xxxxxxxx --dry-run`
- `uv run --with-requirements cookbook/requirements.txt python -m py_compile cookbook/cluster/create_cluster.py`
- `node --test test/*.test.mjs`
- `git diff --check`
- `npm run build`

未处理项:
- 未真实创建 TKE 集群，未执行 DescribeClusters/DeleteCluster 清理链路。

是否仍需 Live Verify:
- 需要。该修改修复请求结构并通过 dry-run 序列化校验，但仍需要真实环境按 issue 验收命令创建、查询并清理集群。
