### PR TITLE
TKE-10: fix create cluster ServiceCIDR mask

### DIFF
--- a/cookbook/cluster/create_cluster.py
+++ b/cookbook/cluster/create_cluster.py
@@ -77,7 +77,7 @@ def create_cluster(
     k8s_version: str = "1.28.3",
     vpc_id: str = None,
     cluster_cidr: str = "172.16.0.0/16",
-    service_cidr: str = "10.96.0.0/16",
+    service_cidr: str = "10.96.0.0/24",
     cluster_level: str = "L5"
 ) -> str:
     """
@@ -202,7 +202,7 @@ def main():
     parser.add_argument('--k8s-version', default='1.28.3', help='Kubernetes 版本')
     parser.add_argument('--vpc-id', help='VPC ID (留空从配置文件读取)')
     parser.add_argument('--cluster-cidr', default='172.16.0.0/16', help='集群 CIDR')
-    parser.add_argument('--service-cidr', default='10.96.0.0/16', help='Service CIDR')
+    parser.add_argument('--service-cidr', default='10.96.0.0/24', help='Service CIDR')
     parser.add_argument('--cluster-level', default='L5', 
                        choices=['L5', 'L20', 'L50', 'L100', 'L200'],
                        help='集群规模')

--- a/src/content/docs/basics/cluster/01-create-cluster.md
+++ b/src/content/docs/basics/cluster/01-create-cluster.md
@@ -9,7 +9,7 @@ title: "如何创建 TKE 集群"
 - **功能名称**: 创建 TKE 集群
 - **API 版本**: 2018-05-25
 - **适用集群版本**: 所有版本
-- **文档更新时间**: 2026-06-16
+- **文档更新时间**: 2026-06-17
 - **Agent 友好度**: ⭐⭐⭐⭐⭐
 
 ---
@@ -58,7 +58,7 @@ title: "如何创建 TKE 集群"
   "ClusterCIDR": "172.16.0.0/16",        // 集群容器网络 CIDR
   "MaxNodePodNum": 64,                    // 每个节点最大 Pod 数
   "MaxClusterServiceNum": 256,            // 集群最大 Service 数
-  "ServiceCIDR": "10.96.0.0/16"          // Service CIDR
+  "ServiceCIDR": "10.96.0.0/24"          // Service CIDR
 }
 ```
 
@@ -108,7 +108,7 @@ curl -X POST "https://tke.tencentcloudapi.com/" \
     "ClusterCIDRSettings": {
       "ClusterCIDR": "172.16.0.0/16",
       "MaxNodePodNum": 64,
-      "ServiceCIDR": "10.96.0.0/16"
+      "ServiceCIDR": "10.96.0.0/24"
     }
   }'
 ```
@@ -135,7 +135,7 @@ tccli tke CreateCluster \
   --ClusterCIDRSettings '{
     "ClusterCIDR": "172.16.0.0/16",
     "MaxNodePodNum": 64,
-    "ServiceCIDR": "10.96.0.0/16"
+    "ServiceCIDR": "10.96.0.0/24"
   }'
 ```
 
@@ -166,7 +166,7 @@ req.ClusterBasicSettings.AutoUpgradeClusterLevel.IsAutoUpgrade = True
 req.ClusterCIDRSettings = models.ClusterCIDRSettings()
 req.ClusterCIDRSettings.ClusterCIDR = "172.16.0.0/16"
 req.ClusterCIDRSettings.MaxNodePodNum = 64
-req.ClusterCIDRSettings.ServiceCIDR = "10.96.0.0/16"
+req.ClusterCIDRSettings.ServiceCIDR = "10.96.0.0/24"
 
 # 发起请求
 resp = client.CreateCluster(req)
@@ -206,7 +206,7 @@ func main() {
 	request.ClusterCIDRSettings = &tke.ClusterCIDRSettings{
 		ClusterCIDR:           common.StringPtr("172.16.0.0/16"),
 		MaxNodePodNum:         common.Uint64Ptr(64),
-		ServiceCIDR:           common.StringPtr("10.96.0.0/16"),
+		ServiceCIDR:           common.StringPtr("10.96.0.0/24"),
 	}
 
 	response, err := client.CreateCluster(request)
@@ -406,7 +406,7 @@ tccli tke EnableClusterDeletionProtection \
 - VPC ID: {{vpc_id}}
 - 集群类型: 托管集群
 - 容器网络 CIDR: 172.16.0.0/16
-- Service CIDR: 10.96.0.0/16
+- Service CIDR: 10.96.0.0/24
 - 集群规模: L5
 ```
 
@@ -431,7 +431,7 @@ tccli tke EnableClusterDeletionProtection \
 1. **集群命名规范**: 使用 `{env}-{project}-{region}` 格式,如 `prod-api-gz`
 2. **网络规划**: 
    - ClusterCIDR 建议使用 /16 网段,支持更多 Pod
-   - ServiceCIDR 建议使用 /16 网段,避免与 ClusterCIDR 冲突
+   - ServiceCIDR 掩码需使用 TKE API 接受的 /17 到 /27 范围；示例采用 /24,并需避免与 VPC CIDR、ClusterCIDR 及同 VPC 内其他集群 CIDR 冲突
 3. **集群规模选择**: 
    - L5: ≤5 节点,适合测试环境
    - L20: 6-20 节点,适合小型生产
@@ -475,5 +475,5 @@ python3 cookbook/cluster/create_cluster.py \
 ---
 
 **文档版本**: v1.0<br>
-**最后更新**: 2026-06-16<br>
+**最后更新**: 2026-06-17<br>
 **维护者**: TKE Documentation Team

--- a/test/create-cluster-autoupgrade.test.mjs
+++ b/test/create-cluster-autoupgrade.test.mjs
@@ -53,3 +53,31 @@ test('create cluster documentation shows AutoUpgradeClusterLevel as an object', 
     'documentation should show AutoUpgradeClusterLevel.IsAutoUpgrade'
   );
 });
+
+test('create cluster examples use a valid ServiceCIDR mask', () => {
+  assert.doesNotMatch(
+    cookbookSource,
+    /10\.96\.0\.0\/16/,
+    'cookbook default ServiceCIDR must not use /16'
+  );
+  assert.match(
+    cookbookSource,
+    /service_cidr:\s*str\s*=\s*"10\.96\.0\.0\/24"/,
+    'cookbook should default ServiceCIDR to a /24 range'
+  );
+  assert.match(
+    cookbookSource,
+    /--service-cidr',\s*default='10\.96\.0\.0\/24'/,
+    'CLI --service-cidr default should match the valid /24 range'
+  );
+  assert.doesNotMatch(
+    createClusterDoc,
+    /10\.96\.0\.0\/16/,
+    'documentation must not show invalid /16 Service CIDR examples'
+  );
+  assert.match(
+    createClusterDoc,
+    /Service CIDR: 10\.96\.0\.0\/24/,
+    'Agent prompt should show the valid /24 Service CIDR'
+  );
+});


### PR DESCRIPTION
Closes TKE-10

## Doc Change Report

### Source issue

- TKE-10: 文档变更: `src/content/docs/basics/cluster/01-create-cluster.md` - 修正 ServiceCIDR 掩码范围
- Source Live Verify issue: TKE-9 (`ec873280-eced-40af-9e23-e291e5e7ab5b`)

### 修改范围

- `src/content/docs/basics/cluster/01-create-cluster.md`
  - 将 API、tccli、Python、Go 和 Agent Prompt 中的 `ServiceCIDR` 示例从 `10.96.0.0/16` 改为 `10.96.0.0/24`
  - 将网络规划建议从推荐 `/16` 改为说明 TKE API 接受 `/17` 到 `/27`,示例采用 `/24`
- `cookbook/cluster/create_cluster.py`
  - 将 `create_cluster()` 和 `--service-cidr` 默认值改为 `10.96.0.0/24`
- `test/create-cluster-autoupgrade.test.mjs`
  - 增加回归测试,防止 create-cluster 文档和 cookbook 再次出现 `10.96.0.0/16`

### 事实来源

- TKE-10 issue / Live Verify evidence: TKE API returned `InvalidParameter.CidrMaskSizeOutOfRange` with message `serviceCIDR mask size must be in 17-27`.
  - 采用理由: 真实 CreateCluster API 请求在创建前被服务端参数校验拒绝,直接证明当前 `/16` 示例不可用。
- Tencent Cloud official data type doc: https://cloud.tencent.com/document/product/457/31866
  - 官方页面更新时间: 2026-06-15 01:58:31
  - Relevant section: `ClusterCIDRSettings.ServiceCIDR`
  - 采用理由: 官方 API 数据结构说明 `ServiceCIDR` 用于分配集群服务 IP,不得与 VPC CIDR 或同 VPC 其他集群 CIDR 冲突,且官方示例值为 `10.0.255.0/24`; `/24` 落在 Live Verify 返回的 `/17` 到 `/27` 服务端范围内。
- Tencent Cloud official CreateCluster API doc: https://intl.cloud.tencent.com/ind/document/product/457/32027
  - 官方页面更新时间: 2026-05-27 13:00:50
  - 采用理由: 确认 `CreateCluster` 使用 `ClusterCIDRSettings` 作为集群容器网络配置参数。
- Repository source: `cookbook/cluster/create_cluster.py`, `test/create-cluster-autoupgrade.test.mjs`
  - 采用理由: 保持文档示例、cookbook 默认值和现有 CreateCluster 序列化测试一致。

### Static Compile

- `python3 -m py_compile cookbook/cluster/create_cluster.py` passed.
- `node --test test/*.test.mjs` passed: 10/10 tests.
- `git diff --check` passed.
- `npm run build` passed after installing local dependencies.
- MkDocs skipped: repository has no `mkdocs.yml` or `mkdocs.yaml`.

### Dry Run Compile

- `uv run --with-requirements cookbook/requirements.txt python cookbook/cluster/create_cluster.py --cluster-name doc-audit-test --region ap-guangzhou --vpc-id vpc-xxxxxxxx --dry-run` passed.
- Dry-run serialization now includes:
  - `ClusterCIDRSettings.ServiceCIDR: "10.96.0.0/24"`
  - `ClusterBasicSettings.AutoUpgradeClusterLevel: { "IsAutoUpgrade": true }`

### Live Verify

- Required.
- Follow-up Live Verify should retry `CreateCluster` with execution-layer `ClusterBasicSettings.TagSpecification` carrying `billing:virgilliang`, then run `DescribeClusters` and `DeleteCluster` cleanup.

### 剩余人工确认项

- None from this doc-change pass.
