### PR TITLE
TKE-29: align DeleteCluster resource options

### DIFF
--- a/cookbook/cluster/delete_cluster.py
+++ b/cookbook/cluster/delete_cluster.py
@@ -2,7 +2,7 @@
 """
 删除 TKE 集群示例脚本
 
-功能: 删除指定 TKE 集群，并显式选择节点与关联资源删除策略
+功能: 删除指定 TKE 集群，并显式选择节点与 CBS 删除策略
 使用方法: python3 delete_cluster.py --cluster-id cls-xxxxxxxx --region ap-guangzhou --confirm-delete
 文档链接: https://tke-workshop.github.io/basics/cluster/02-delete-cluster/
 """
@@ -22,14 +22,11 @@ from tencentcloud.common.exception.tencent_cloud_sdk_exception import TencentClo
 logger = setup_logger(__name__)
 
 
-def build_resource_delete_options(cbs_mode: str, clb_mode: str) -> list[models.ResourceDeleteOption]:
-    options = []
-    for resource_type, delete_mode in (("CBS", cbs_mode), ("CLB", clb_mode)):
-        option = models.ResourceDeleteOption()
-        option.ResourceType = resource_type
-        option.DeleteMode = delete_mode
-        options.append(option)
-    return options
+def build_resource_delete_options(cbs_mode: str) -> list[models.ResourceDeleteOption]:
+    option = models.ResourceDeleteOption()
+    option.ResourceType = "CBS"
+    option.DeleteMode = cbs_mode
+    return [option]
 
 
 def describe_cluster(client, cluster_id: str):
@@ -46,7 +43,6 @@ def delete_cluster(
     region: str,
     instance_delete_mode: str = "terminate",
     cbs_delete_mode: str = "terminate",
-    clb_delete_mode: str = "terminate",
     disable_deletion_protection: bool = False,
     confirm_delete: bool = False,
 ):
@@ -64,7 +60,7 @@ def delete_cluster(
         logger.info(f"集群状态: {cluster.ClusterStatus}")
         logger.info(f"节点删除策略: {instance_delete_mode}")
         logger.info(f"CBS 删除策略: {cbs_delete_mode}")
-        logger.info(f"CLB 删除策略: {clb_delete_mode}")
+        logger.info("CLB 不作为 ResourceDeleteOptions 入参配置；删除后请按文档验证是否有遗留 CLB。")
 
         deletion_protection = getattr(cluster, "DeletionProtection", None)
         if deletion_protection:
@@ -87,7 +83,7 @@ def delete_cluster(
         req = models.DeleteClusterRequest()
         req.ClusterId = cluster_id
         req.InstanceDeleteMode = instance_delete_mode
-        req.ResourceDeleteOptions = build_resource_delete_options(cbs_delete_mode, clb_delete_mode)
+        req.ResourceDeleteOptions = build_resource_delete_options(cbs_delete_mode)
 
         try:
             resp = client.DeleteCluster(req)
@@ -135,19 +131,18 @@ def main():
   # 预检查删除计划，不提交删除
   python3 delete_cluster.py --cluster-id cls-xxxxxxxx --region ap-guangzhou
 
-  # 删除测试集群并销毁节点、CBS、CLB
+  # 删除测试集群并销毁节点和 CBS；删除后检查是否有遗留 CLB
   python3 delete_cluster.py \\
     --cluster-id cls-xxxxxxxx \\
     --region ap-guangzhou \\
     --confirm-delete \\
     --wait
 
-  # 删除集群但保留节点、CBS、CLB
+  # 删除集群但保留节点和 CBS；删除后检查是否有遗留 CLB
   python3 delete_cluster.py \\
     --cluster-id cls-xxxxxxxx \\
     --instance-delete-mode retain \\
     --cbs-delete-mode retain \\
-    --clb-delete-mode retain \\
     --confirm-delete
         """,
     )
@@ -165,12 +160,6 @@ def main():
         default="terminate",
         choices=["terminate", "retain"],
         help="CBS 删除策略",
-    )
-    parser.add_argument(
-        "--clb-delete-mode",
-        default="terminate",
-        choices=["terminate", "retain"],
-        help="CLB 删除策略",
     )
     parser.add_argument(
         "--disable-deletion-protection",
@@ -193,7 +182,6 @@ def main():
             region=args.region,
             instance_delete_mode=args.instance_delete_mode,
             cbs_delete_mode=args.cbs_delete_mode,
-            clb_delete_mode=args.clb_delete_mode,
             disable_deletion_protection=args.disable_deletion_protection,
             confirm_delete=args.confirm_delete,
         )

--- a/src/content/docs/basics/cluster/02-delete-cluster.md
+++ b/src/content/docs/basics/cluster/02-delete-cluster.md
@@ -39,7 +39,7 @@ title: "如何删除 TKE 集群"
 - [ ] **数据备份**: 已备份集群中的重要数据、ConfigMap、Secret
 - [ ] **应用迁移**: 已迁移或下线集群中的应用
 - [ ] **删除保护**: 检查是否启用了删除保护
-- [ ] **关联资源**: 确认要保留还是删除关联的 CLB、CBS 等资源
+- [ ] **关联资源**: 确认要保留还是删除关联的 CBS，并记录需要删除后核查的 CLB 等资源
 - [ ] **费用结算**: 确认是否有未结算的费用
 
 ---
@@ -91,10 +91,6 @@ curl -X POST "https://tke.tencentcloudapi.com/" \
       {
         "ResourceType": "CBS",
         "DeleteMode": "terminate"
-      },
-      {
-        "ResourceType": "CLB",
-        "DeleteMode": "terminate"
       }
     ]
   }'
@@ -121,10 +117,6 @@ tccli tke DeleteCluster \
     {
       "ResourceType": "CBS",
       "DeleteMode": "terminate"
-    },
-    {
-      "ResourceType": "CLB",
-      "DeleteMode": "terminate"
     }
   ]'
 ```
@@ -135,7 +127,7 @@ tccli tke DeleteCluster \
 |--------|------|------|------|--------|
 | ClusterId | 是 | String | 集群 ID | - |
 | InstanceDeleteMode | 是 | String | 节点删除策略 | terminate(销毁) / retain(保留) |
-| ResourceDeleteOptions | 否 | Array | 资源删除策略 | 见下表 |
+| ResourceDeleteOptions | 否 | Array | 资源删除策略；DeleteCluster 当前仅支持 CBS，默认保留 CBS | 见下表 |
 
 **ResourceDeleteOptions 说明**:
 
@@ -143,8 +135,8 @@ tccli tke DeleteCluster \
 |--------------|------------|------|
 | CBS | terminate | 销毁云硬盘 |
 | CBS | retain | 保留云硬盘 |
-| CLB | terminate | 销毁负载均衡器 |
-| CLB | retain | 保留负载均衡器 |
+
+> 注意: DeleteCluster API 的 `ResourceDeleteOptions` 当前仅支持 CBS。CLB 不应作为 `ResourceDeleteOptions` 入参传递；请在集群删除完成后按验证步骤检查是否仍有遗留 CLB。
 
 **使用 Python SDK**:
 
@@ -164,11 +156,7 @@ option1 = models.ResourceDeleteOption()
 option1.ResourceType = "CBS"
 option1.DeleteMode = "terminate"
 
-option2 = models.ResourceDeleteOption()
-option2.ResourceType = "CLB"
-option2.DeleteMode = "terminate"
-
-req.ResourceDeleteOptions = [option1, option2]
+req.ResourceDeleteOptions = [option1]
 
 resp = client.DeleteCluster(req)
 print(f"RequestId: {resp.RequestId}")
@@ -196,10 +184,6 @@ func main() {
 	request.ResourceDeleteOptions = []*tke.ResourceDeleteOption{
 		{
 			ResourceType: common.StringPtr("CBS"),
-			DeleteMode:   common.StringPtr("terminate"),
-		},
-		{
-			ResourceType: common.StringPtr("CLB"),
 			DeleteMode:   common.StringPtr("terminate"),
 		},
 	}
@@ -308,15 +292,16 @@ tccli clb DescribeLoadBalancers \
 
 ### 资源删除策略
 
+DeleteCluster API 的 `ResourceDeleteOptions` 当前仅支持 CBS；未显式传入时默认保留 CBS。CLB 等关联资源不能通过 `ResourceDeleteOptions` 设置 `retain` 或 `terminate`，请在删除后通过验证步骤检查是否仍有遗留资源。
+
 | 资源类型 | terminate 策略 | retain 策略 |
 |---------|---------------|------------|
 | CBS(云硬盘) | 销毁数据盘和系统盘 | 保留数据盘,销毁系统盘 |
-| CLB(负载均衡) | 销毁所有 Service 创建的 CLB | 保留 CLB,解除与集群关联 |
 
 **最佳实践**:
 - 测试环境: 使用 `terminate` 彻底清理资源
 - 生产环境: 先手动备份数据,再使用 `terminate`
-- 特殊需求: 使用 `retain` 保留特定资源
+- 特殊需求: 使用 `retain` 保留 CBS，并记录删除后需要人工核查的关联资源
 
 ---
 
@@ -380,7 +365,7 @@ kubectl exec -n "${NAMESPACE}" "${POD_NAME}" -- tar czf - /data | \
 - 集群ID: {{cluster_id}}
 - 保留节点: 是
 - 保留云硬盘: 是
-- 保留负载均衡器: 是
+- 删除后核查负载均衡器是否遗留: 是
 ```
 
 ### 批量删除 Prompt

--- a/src/data/cookbooks.js
+++ b/src/data/cookbooks.js
@@ -190,7 +190,7 @@ export const cookbooks = [
     }),
     risk: {
       level: '高',
-      cost: '会删除真实 TKE 集群，并可能销毁 CVM 节点、云硬盘和负载均衡器。',
+      cost: '会删除真实 TKE 集群，并可能销毁 CVM 节点和云硬盘；删除后需检查是否有遗留负载均衡器。',
       resourceImpact: '删除云资源',
       notice: '脚本默认 dry-run；执行 --confirm-delete 前必须完成数据备份、删除保护检查和资源保留策略确认。',
     },
@@ -226,12 +226,6 @@ export const cookbooks = [
         description: 'CBS 删除策略，可选 terminate 或 retain。',
       },
       {
-        name: '--clb-delete-mode',
-        required: false,
-        example: 'retain',
-        description: 'CLB 删除策略，可选 terminate 或 retain。',
-      },
-      {
         name: '--wait',
         required: false,
         example: '--wait',
@@ -251,7 +245,7 @@ export const cookbooks = [
     prerequisites: [
       '已准备腾讯云 SecretId 和 SecretKey。',
       '已复制 cookbook/config.example.yaml 为 cookbook/config.yaml。',
-      '已确认目标 ClusterId、地域、备份状态、删除保护状态和资源保留策略。',
+      '已确认目标 ClusterId、地域、备份状态、删除保护状态、CBS 删除策略和删除后需要核查的关联资源。',
     ],
     commands: [
       'cd cookbook',
@@ -264,12 +258,12 @@ export const cookbooks = [
       '确认返回 ResourceNotFound.ClusterNotFound，或查询结果中不再包含该集群。',
     ],
     cleanup: [
-      '检查 CVM、CBS、CLB、公网 IP 等关联计费资源是否按策略删除或保留。',
+      '检查 CVM、CBS、CLB、公网 IP 等关联计费资源是否已删除或按预期保留。',
       '如选择 retain，记录保留资源清单和后续负责人。',
       '确认本次操作产生的日志和备份文件已按团队要求归档。',
     ],
     prompt:
-      '请根据 TKE Workshop 的 delete-cluster Cookbook，先对 cls-xxxxxxxx 输出 dry-run 删除计划，确认备份、删除保护和资源保留策略后，再提交删除并等待完成。',
+      '请根据 TKE Workshop 的 delete-cluster Cookbook，先对 cls-xxxxxxxx 输出 dry-run 删除计划，确认备份、删除保护和 CBS 删除策略后，再提交删除、等待完成并检查关联资源。',
   },
   {
     id: 'describe-clusters',


### PR DESCRIPTION
## Summary

Align the DeleteCluster documentation and cookbook with the action-specific Tencent Cloud API contract: `ResourceDeleteOptions` currently supports CBS only, so CLB is no longer shown as a request option or script parameter.

## Doc Change Report

- Source issue: TKE-29
- Modified scope:
  - `src/content/docs/basics/cluster/02-delete-cluster.md`
  - `cookbook/cluster/delete_cluster.py`
  - `src/data/cookbooks.js`
- Fact sources:
  - Tencent Cloud DeleteCluster API: https://cloud.tencent.com/document/product/457/36704, last updated 2025-11-05 02:23:06. Adopted because this is the action-specific API page and says `ResourceDeleteOptions.N` currently supports CBS, with CBS retained by default.
  - Tencent Cloud SDK Python model: https://raw.githubusercontent.com/TencentCloud/tencentcloud-sdk-python/master/tencentcloud/tke/v20180525/models.py. Adopted as SDK confirmation that `DeleteClusterRequest.ResourceDeleteOptions` is documented as currently supporting CBS.
  - Tencent Cloud data type page: https://www.tencentcloud.com/document/product/457/32022, last updated 2026-01-07 15:42:28 per page metadata. Considered as a broader type reference; it lists CBS/CLB/CVM examples but describes `DeleteMode` as applying to CBS while other resources default to termination, so the action-specific DeleteCluster page is the safer source for examples and cookbook input surface.
- Static Compile:
  - `python3 -m py_compile cookbook/cluster/delete_cluster.py` passed.
  - `node --test test/cookbooks.test.mjs test/navigation.test.mjs` passed.
  - `git diff --check` passed.
  - No `mkdocs.yml` or `mkdocs.yaml` exists, so `mkdocs build --strict` was skipped.
- Dry Run Compile:
  - `npm run build` passed after installing declared npm dependencies locally.
  - The cookbook remains dry-run by default and does not submit `DeleteCluster` unless `--confirm-delete` is passed.
- Live Verify:
  - Required for real deletion behavior only. This PR did not create, delete, or modify Tencent Cloud resources.
- Remaining human confirmation:
  - None for the documented API input alignment. Real CLB cleanup behavior should still be verified by a Live Verify run if required by release policy.

## Validation

```text
python3 -m py_compile cookbook/cluster/delete_cluster.py
node --test test/cookbooks.test.mjs test/navigation.test.mjs
git diff --check
npm run build
```
