### PR TITLE
TKE-13: fix describe clusters cookbook import

### DIFF
--- a/cookbook/cluster/describe_clusters.py
+++ b/cookbook/cluster/describe_clusters.py
@@ -7,6 +7,8 @@
 文档链接: https://tke-workshop.github.io/basics/cluster/04-describe-clusters/
 """
 
+from __future__ import annotations
+
 import argparse
 import sys
 from pathlib import Path


### PR DESCRIPTION
Closes TKE-13

## Summary
- Add postponed annotation evaluation to cookbook/cluster/describe_clusters.py so the referenced cookbook can render CLI help under Python 3.9.
- This keeps the DescribeClusters API behavior unchanged and only fixes import-time compatibility for the doc pipeline dry-run check.

## Verification
- npm run build
- node --test test/cookbooks.test.mjs test/navigation.test.mjs
- /usr/bin/python3 -m py_compile cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py
- python3 -m py_compile cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py
- /usr/bin/python3 cookbook/cluster/describe_clusters.py --help
- git diff --check

## Notes
- Upstream push was denied for the authenticated account, so this PR uses the configured fork branch as the head.