### PR TITLE
TKE-14: mark node output fence as text

### DIFF
--- a/src/content/docs/basics/node/01-add-node.md
+++ b/src/content/docs/basics/node/01-add-node.md
@@ -328,7 +328,7 @@ kubectl get nodes -o wide
 
 **期望结果**:
 
-```
+```text
 NAME            STATUS   ROLES    AGE   VERSION
 tke-node-xxx1   Ready    <none>   2m    v1.28.3
 tke-node-xxx2   Ready    <none>   2m    v1.28.3


### PR DESCRIPTION
## Summary
- Mark the expected node status output block in src/content/docs/basics/node/01-add-node.md as text.
- Keeps the single-page doc pipeline fix scoped to the target document.

## Validation
- npm run build
- python3 -m py_compile cookbook/common/logger.py cookbook/common/auth.py cookbook/cluster/describe_clusters.py cookbook/cluster/create_cluster.py cookbook/cluster/delete_cluster.py cookbook/supernode/deploy_gpu_pod.py cookbook/workload/deploy_nginx.py
- git diff --check
- node --check src/data/cookbooks.js && node --check src/data/navigation.mjs

Closes TKE-14