### PR TITLE
TKE-16: fix describe node placeholder

### DIFF
--- a/src/content/docs/basics/node/04-describe-nodes.md
+++ b/src/content/docs/basics/node/04-describe-nodes.md
@@ -362,7 +362,7 @@ kubectl get nodes
 kubectl get nodes -o wide
 
 # 查看节点详情
-kubectl describe node <node-name>
+kubectl describe node "${NODE_NAME}"
 
 # 按标签过滤节点
 kubectl get nodes -l env=production


### PR DESCRIPTION
## Summary
- Replace the invalid shell placeholder in the kubectl describe node example with a shell-variable form.
- Completed the scoped Static/Dry Run Compile checks for src/content/docs/basics/node/04-describe-nodes.md.

## Verification
- npm run build
- node --test test/navigation.test.mjs test/cookbooks.test.mjs test/create-cluster-autoupgrade.test.mjs
- python3 -m py_compile via find cookbook -name '*.py'
- fenced code block syntax validation for bash/python/go/json in src/content/docs/basics/node/04-describe-nodes.md
- local Markdown link/image target check for src/content/docs/basics/node/04-describe-nodes.md
- git diff --check