### PR TITLE
TKE-20: fix service doc compile hygiene

### DIFF
--- a/src/content/docs/basics/service/01-create-service.md
+++ b/src/content/docs/basics/service/01-create-service.md
@@ -92,7 +92,7 @@ kubectl run test-pod --image=busybox:1.28 --rm -it --restart=Never -- \
 
 **期望输出**:
 
-```
+```text
 NAME         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
 my-app-svc   ClusterIP   10.96.123.45    <none>        80/TCP    1m
 ```
@@ -299,7 +299,7 @@ curl http://$LB_DOMAIN
 
 **期望输出**:
 
-```
+```text
 NAME               TYPE           CLUSTER-IP     EXTERNAL-IP                        PORT(S)        AGE
 my-app-lb-public   LoadBalancer   10.96.45.67    xxx.clb.myqcloud.com              80:31234/TCP   2m
 ```
@@ -345,8 +345,9 @@ kubectl apply -f service-lb-internal.yaml
 kubectl get svc my-app-lb-internal
 
 # 从集群内部测试
+CLUSTER_IP=$(kubectl get svc my-app-lb-internal -o jsonpath='{.spec.clusterIP}')
 kubectl run test --image=busybox:1.28 --rm -it --restart=Never -- \
-  wget -O- http://<CLUSTER-IP>
+  wget -O- http://$CLUSTER_IP
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Mark Service expected-output fences as `text` so all code blocks have explicit languages.
- Replace the internal LoadBalancer verification placeholder URL with a concrete `CLUSTER_IP` lookup before the test pod command.

## Validation

- `npm run build`
- `node --test test/navigation.test.mjs test/cookbooks.test.mjs`
- `python3 -m py_compile cookbook/cluster/create_cluster.py cookbook/cluster/delete_cluster.py cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py cookbook/supernode/deploy_gpu_pod.py cookbook/workload/deploy_nginx.py`
- `git diff --check`
- Target page code fence scan: no unlabeled fences; JSON parsed; Bash snippets passed `bash -n`; YAML snippets parsed with Ruby Psych.

No live TKE resources were created or modified. Live verification is still required for the real Service operations described by this page.
