### PR TITLE
TKE-21: mark supernode expected output fence

### DIFF
--- a/src/content/docs/basics/supernode/01-create-supernode-pool.md
+++ b/src/content/docs/basics/supernode/01-create-supernode-pool.md
@@ -205,7 +205,7 @@ kubectl get pods -n kube-system | grep virtual-kubelet
 
 **期望结果**:
 
-```
+```text
 NAME                                READY   STATUS    RESTARTS   AGE
 virtual-kubelet-np-xxxxxxxx-xxxxx   1/1     Running   0          2m
 ```


### PR DESCRIPTION
## Summary
- Mark the expected-output fence in `src/content/docs/basics/supernode/01-create-supernode-pool.md` as `text`.
- Keep the compile sweep scoped to TKE-21 with no API semantic changes.

## Validation
- `npm run build`
- `node --test test/navigation.test.mjs test/cookbooks.test.mjs`
- `python3 -m py_compile cookbook/supernode/deploy_gpu_pod.py`
- page-specific code fence checks for JSON/Bash/Python/Go/text blocks
- page-specific local Markdown link existence check
- `git diff --check`

TKE-21
