### PR TITLE
TKE-22: label supernode expected output fence

### DIFF
--- a/src/content/docs/basics/supernode/02-create-supernode.md
+++ b/src/content/docs/basics/supernode/02-create-supernode.md
@@ -180,7 +180,7 @@ kubectl get nodes -o wide
 
 **期望结果**:
 
-```
+```text
 NAME                         STATUS   ROLES    AGE   VERSION
 eklet-subnet-xxxxxxxx-0      Ready    agent    1m    v1.28.3-tke.1
 ```


### PR DESCRIPTION
## Compile Sweep Report

Source issue: TKE-22

### Scope
- Target document: `src/content/docs/basics/supernode/02-create-supernode.md`
- Direct references checked: neighboring supernode docs, related node doc, related supernode cookbook files, navigation/test coverage

### Change
- Labeled the expected `kubectl get nodes -o wide` output fence as `text` so the page has no unlabeled code block.

### Static Compile
- `npm run build`
- `node --test test/navigation.test.mjs test/cookbooks.test.mjs`
- `python3 -m py_compile cookbook/supernode/deploy_gpu_pod.py cookbook/common/auth.py cookbook/common/logger.py`
- `ruby -e 'require "yaml"; YAML.load_file("cookbook/supernode/gpu_pod_examples.yaml"); puts "yaml ok"'`
- focused local-link scan for `src/content/docs/basics/supernode/02-create-supernode.md`
- focused code-fence-language scan for `src/content/docs/basics/supernode/02-create-supernode.md`
- `git diff --check`

### Dry Run Compile
- Confirmed required API parameters and response shape against Tencent Cloud official CreateClusterVirtualNode API docs, last updated 2025-08-13.
- Commands remain placeholder-based and should not be executed without substituting `ClusterId`, `NodePoolId`, `SubnetId`, and region.
- No real cloud resources were created, changed, or deleted.

### Skipped
- `mkdocs build --strict`: skipped because this repo has no MkDocs config; it is an Astro/Starlight site.
- Live verification: skipped by this agent role; this document involves real TKE/Tencent Cloud operations and should be routed to Live Verify after review.

### Follow-up
- Live verification is still required for the real TKE operation path.
