### PR TITLE
TKE-23: fix delete supernode doc whitespace

### DIFF
--- a/src/content/docs/basics/supernode/03-delete-supernode.md
+++ b/src/content/docs/basics/supernode/03-delete-supernode.md
@@ -309,28 +309,28 @@ NODE_NAMES=(
 
 for node in "${NODE_NAMES[@]}"; do
   echo "处理节点: $node"
-  
+
   # 驱逐 Pod
   kubectl drain $node \
     --ignore-daemonsets \
     --delete-emptydir-data \
     --force \
     --grace-period=300
-  
+
   if [ $? -eq 0 ]; then
     echo "驱逐成功，开始删除节点"
-    
+
     # 删除节点
     tccli tke DeleteClusterVirtualNode \
       --Region $REGION \
       --ClusterId $CLUSTER_ID \
       --NodeNames "[\"$node\"]"
-    
+
     echo "节点 $node 删除完成"
   else
     echo "节点 $node 驱逐失败，跳过删除"
   fi
-  
+
   sleep 5
 done
 ```
@@ -352,7 +352,7 @@ def delete_virtual_node_safely(cluster_id, node_name, force=False):
     """安全删除虚拟节点"""
     # 检查节点上的 Pod
     pods = check_node_pods(node_name)
-    
+
     if pods and not force:
         print(f"警告: 节点 {node_name} 上有运行中的 Pod:")
         print(pods)
@@ -364,12 +364,12 @@ def delete_virtual_node_safely(cluster_id, node_name, force=False):
     # 执行删除
     cred = credential.Credential("SecretId", "SecretKey")
     client = tke_client.TkeClient(cred, "ap-guangzhou")
-    
+
     req = models.DeleteClusterVirtualNodeRequest()
     req.ClusterId = cluster_id
     req.NodeNames = [node_name]
     req.Force = force
-    
+
     try:
         resp = client.DeleteClusterVirtualNode(req)
         print(f"删除成功, 请求ID: {resp.RequestId}")
@@ -465,6 +465,8 @@ delete_virtual_node_safely("cls-xxxxxxxx", "eklet-subnet-xxxxxxxx-0")
 
 ---
 
-**文档版本**: v1.0  
-**最后更新**: 2026-01-07  
+**文档版本**: v1.0
+
+**最后更新**: 2026-01-07
+
 **维护者**: TKE Documentation Team


### PR DESCRIPTION
## Summary

- Normalize trailing whitespace in `src/content/docs/basics/supernode/03-delete-supernode.md`.
- Preserve the existing content and command semantics; no API, pricing, version, or production-operation guidance was changed.

## Compile Sweep Report

- Scope: `src/content/docs/basics/supernode/03-delete-supernode.md` and direct navigation/cookbook/test references.
- Static compile: passed after the whitespace-only fix.
- Dry run compile: commands and examples are structurally copyable with placeholders; deletion is a real TKE operation, so live verification is still required.
- Follow-up: created TKE-34 for Doc Change Agent to resolve the document's dangling “TKE 超级节点删除 Cookbook” reference, because no matching deletion cookbook exists in the repo.

## Validation

- `npm install --no-package-lock`
- `npm run build`
- `node --test test/*.test.mjs`
- `python3 -m py_compile cookbook/supernode/deploy_gpu_pod.py cookbook/common/auth.py cookbook/common/logger.py`
- `git diff --check`
- `git diff --cached --check`

## Notes

- `mkdocs build --strict` was skipped because the repository has no `mkdocs.yml` or `mkdocs.yaml`.
- `npm install` reported 6 high severity dependency advisories; no dependency changes were made.
