### PR TITLE
TKE-24: fix deployment doc compile issues

### DIFF
--- a/src/content/docs/basics/workload/01-create-deployment.md
+++ b/src/content/docs/basics/workload/01-create-deployment.md
@@ -364,6 +364,7 @@ import (
     corev1 "k8s.io/api/core/v1"
     "k8s.io/apimachinery/pkg/api/resource"
     metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+    "k8s.io/apimachinery/pkg/util/intstr"
     "k8s.io/client-go/kubernetes"
     "k8s.io/client-go/tools/clientcmd"
 )
@@ -745,7 +746,7 @@ kubectl describe quota -n default
 
 ## Cookbook 示例
 
-完整可执行示例：create-deployment-example.py
+完整可执行示例：[部署 Nginx Cookbook](/cookbooks/deploy-nginx/)；源码见 [`cookbook/workload/deploy_nginx.py`](https://github.com/tke-workshop/tke-workshop.github.io/blob/main/cookbook/workload/deploy_nginx.py)。
 
 ---
 


### PR DESCRIPTION
Summary
- Add the missing Go intstr import used by the Deployment sample.
- Replace the stale cookbook example filename with the actual deploy-nginx cookbook and source link.

Validation
- npm run build
- node --test test/cookbooks.test.mjs test/navigation.test.mjs
- python3 -m py_compile cookbook/workload/deploy_nginx.py
- git diff --check
- Target-page fenced snippet syntax check for JSON, Python, and Go formatting

Dry-run notes
- Static and dry-run compile passed for the scoped document and direct cookbook references.
- Real TKE execution was not performed; live verification is still required for resource creation behavior.