### PR TITLE
TKE-38: make node-pool describe examples copyable

### DIFF
--- a/src/content/docs/basics/node-pool/03-describe-node-pool.md
+++ b/src/content/docs/basics/node-pool/03-describe-node-pool.md
@@ -118,14 +118,16 @@ print(resp.NodePool.Name)
 ## Kubernetes 侧验证
 
 ```bash
+NODE_NAME=your-node-name
+
 # 查看属于某个节点池的节点
 kubectl get nodes -l node-pool=production-pool -o wide
 
 # 查看节点标签和污点
-kubectl describe node <node-name>
+kubectl describe node "$NODE_NAME"
 
 # 查看节点上的 Pod
-kubectl get pods -A -o wide --field-selector spec.nodeName=<node-name>
+kubectl get pods -A -o wide --field-selector spec.nodeName="$NODE_NAME"
 ```
 
 ---


### PR DESCRIPTION
Summary
- Updates the Kubernetes-side validation snippet in src/content/docs/basics/node-pool/03-describe-node-pool.md to use a NODE_NAME variable instead of raw angle-bracket placeholders.
- Keeps the fix scoped to the single target document from TKE-38.

Root cause
The fenced block is marked as bash, but literal <node-name> placeholders are parsed as shell redirection, so copy/paste syntax validation fails.

Validation
- npm run build
- node --test test/navigation.test.mjs test/cookbooks.test.mjs test/create-cluster-autoupgrade.test.mjs
- python3 -m py_compile cookbook/cluster/delete_cluster.py cookbook/cluster/create_cluster.py cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py cookbook/workload/deploy_nginx.py cookbook/supernode/deploy_gpu_pod.py
- git diff --check
- targeted checks for target Markdown fence languages, relative links, bash snippets, and Python snippets

Closes TKE-38