### PR TITLE
TKE-42: fix navigation test expectation

### DIFF
--- a/test/navigation.test.mjs
+++ b/test/navigation.test.mjs
@@ -6,7 +6,7 @@ import { getActiveNavItem, workshopNavItems } from '../src/data/navigation.mjs';
 test('exposes one shared top-level navigation model', () => {
   assert.deepEqual(
     workshopNavItems.map((item) => item.label),
-    ['Start', '基础操作', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
+    ['Start', '基础操作', '网络', '存储', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
   );
 });
 


### PR DESCRIPTION
Summary: updates the shared navigation test expectation to include the current top-level 网络 and 存储 sections. No document content or API semantics changed. Validation: npm run build; node --test test/navigation.test.mjs test/cookbooks.test.mjs test/create-cluster-autoupgrade.test.mjs; python3 -m py_compile cookbook/common/*.py cookbook/cluster/*.py cookbook/workload/*.py cookbook/supernode/*.py; git diff --check. mkdocs build --strict skipped because this repo has no mkdocs executable/config in the checked-out project. Issue: TKE-42