### PR TITLE
TKE-43: fix navigation test expectation

### DIFF
--- a/test/navigation.test.mjs
+++ b/test/navigation.test.mjs
@@ -6,7 +6,7 @@ import { getActiveNavItem, workshopNavItems } from '../src/data/navigation.mjs';
 test('exposes one shared top-level navigation model', () => {
   assert.deepEqual(
     workshopNavItems.map((item) => item.label),
-    ['Start', '基础操作', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
+    ['Start', '基础操作', '网络', '存储', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
   );
 });
 


### PR DESCRIPTION
## Summary

- updates the navigation test expectation to include the current 网络 and 存储 top-level nav items
- keeps the scoped doc compile sweep diff limited to the deterministic test repair

## Root cause

The shared navigation model already includes 网络 and 存储, but the test still asserted the older label list.

## Validation

- npm run build
- node --test test/navigation.test.mjs test/cookbooks.test.mjs
- python3 -m py_compile cookbook/workload/deploy_nginx.py
- git diff --check
- explicit local target-link existence checks for the three links in src/content/docs/basics/kubernetes/02-kubectl-common-operations.md