### PR TITLE
TKE-44: update navigation test expectation

### DIFF
--- a/test/navigation.test.mjs
+++ b/test/navigation.test.mjs
@@ -6,7 +6,7 @@ import { getActiveNavItem, workshopNavItems } from '../src/data/navigation.mjs';
 test('exposes one shared top-level navigation model', () => {
   assert.deepEqual(
     workshopNavItems.map((item) => item.label),
-    ['Start', '基础操作', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
+    ['Start', '基础操作', '网络', '存储', '最佳实践', 'AI on TKE', 'Data on TKE', 'Cookbooks', 'Contribute']
   );
 });
 


### PR DESCRIPTION
## Summary
- Update the shared navigation test expected labels to include the current 网络 and 存储 top-level sections.
- No content/API semantics changed for src/content/docs/basics/kubernetes/01-connect-cluster.md.

## Validation
- npm run build
- node --test test/navigation.test.mjs test/cookbooks.test.mjs
- python3 -m py_compile cookbook/cluster/delete_cluster.py cookbook/cluster/create_cluster.py cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py cookbook/workload/deploy_nginx.py cookbook/supernode/deploy_gpu_pod.py
- git diff --check