### PR TITLE
TKE-46: fix delete node pool parameters

### DIFF
--- a/src/content/docs/basics/node-pool/04-delete-node-pool.md
+++ b/src/content/docs/basics/node-pool/04-delete-node-pool.md
@@ -9,7 +9,7 @@ title: "删除节点池"
 - **功能名称**: 删除标准节点池
 - **API 版本**: 2018-05-25
 - **API 名称**: `DeleteClusterNodePool`
-- **文档更新时间**: 2026-06-17
+- **文档更新时间**: 2026-06-24
 - **Agent 友好度**: ⭐⭐⭐⭐⭐
 
 ---
@@ -25,11 +25,11 @@ title: "删除节点池"
 
 ## 前置条件
 
-- [ ] 已记录 `ClusterId` 和 `NodePoolId`
+- [ ] 已记录 `ClusterId` 和待删除的 `NodePoolId`
 - [ ] 已确认节点池不是核心业务唯一承载池
 - [ ] 已将业务 Pod 迁移到其他节点池
 - [ ] 已确认删除保护状态
-- [ ] 已确认底层 CVM、CBS、EIP 等资源处理策略
+- [ ] 已确认 `KeepInstance` 取值：保留底层 CVM 实例，或随节点池删除释放实例
 
 ---
 
@@ -82,11 +82,17 @@ tccli tke ModifyClusterNodePool \
 
 ### Step 2: 删除节点池
 
+`DeleteClusterNodePool` 支持一次传入多个节点池 ID。删除前必须明确 `KeepInstance`：
+
+- `KeepInstance=true`：删除节点池管理对象并将节点移出集群，但保留对应 CVM 实例。
+- `KeepInstance=false`：删除节点池时不保留对应实例，底层 CVM 等资源可能被释放。
+
 ```bash
 tccli tke DeleteClusterNodePool \
   --Region ap-guangzhou \
   --ClusterId cls-xxxxxxxx \
-  --NodePoolId np-xxxxxxxx
+  --NodePoolIds '["np-xxxxxxxx"]' \
+  --KeepInstance true
 ```
 
 **成功响应示例**:
@@ -108,7 +114,8 @@ client = tke_client.TkeClient(cred, "ap-guangzhou")
 
 req = models.DeleteClusterNodePoolRequest()
 req.ClusterId = "cls-xxxxxxxx"
-req.NodePoolId = "np-xxxxxxxx"
+req.NodePoolIds = ["np-xxxxxxxx"]
+req.KeepInstance = True
 
 resp = client.DeleteClusterNodePool(req)
 print(f"RequestId: {resp.RequestId}")
@@ -143,6 +150,7 @@ kubectl get pods -A -o wide
 
 - 节点池列表中不再返回目标节点池
 - 业务 Pod 已迁移到其他可用节点
+- 如果 `KeepInstance=true`，原节点对应 CVM 实例仍保留，但已不再作为集群节点
 - 集群中没有长时间 `Pending` 的关键 Pod
 
 ---


### PR DESCRIPTION
## Doc Change Report

Source issue: TKE-46

### Scope

- Updated `src/content/docs/basics/node-pool/04-delete-node-pool.md` only.
- Corrected `DeleteClusterNodePool` examples from singular `NodePoolId` to array `NodePoolIds`.
- Added required `KeepInstance` choice in CLI and Python SDK examples.
- Added retain-vs-release reader guidance and verification wording.

### Document Identity

- `canonical_doc_path`: `src/content/docs/basics/node-pool/04-delete-node-pool.md`
- `operation_id`: `tke.nodepool.delete`

No duplicate operation entry was changed in this PR.

### Fact Sources

- Tencent Cloud official API documentation: https://intl.cloud.tencent.com/ind/document/product/457/38779
  - Official page update time: 2026-05-27 13:00:05
  - Adopted because it defines `DeleteClusterNodePool` request parameters as `ClusterId`, `NodePoolIds.N`, and required `KeepInstance`, and describes `KeepInstance=true` as retaining instances while removing nodes from the cluster.
- Repository source page: `src/content/docs/basics/node-pool/04-delete-node-pool.md`
  - Adopted because it is the issue-scoped document containing the incorrect examples.

### Static Compile

- `git diff --check` passed.
- Markdown/code-block language inspection passed for the changed page.
- Command examples were checked against the official API parameter names.
- Python SDK field names were checked against the official API model shape.

### Dry Run Compile

- `node --test test/navigation.test.mjs test/cookbooks.test.mjs test/create-cluster-autoupgrade.test.mjs` passed: 10 tests, 10 pass.
- `python3 -m py_compile cookbook/common/auth.py cookbook/common/logger.py cookbook/cluster/create_cluster.py cookbook/cluster/delete_cluster.py cookbook/cluster/describe_clusters.py cookbook/supernode/deploy_gpu_pod.py cookbook/workload/deploy_nginx.py` passed.
- `npm run build` passed: 184 pages built.
- MkDocs strict build skipped: no `mkdocs.yml` or `mkdocs.yaml` exists in this repo.

### Live Verify

- Live Verify required: no. This change corrects documented API parameter names and examples only; no Tencent Cloud resource creation/deletion was performed or needed.

### Remaining Human Confirmation

- None.
