### PR TITLE
TKE-33: refresh supernode pool optional parameters

### DIFF
--- a/src/content/docs/basics/supernode/01-create-supernode-pool.md
+++ b/src/content/docs/basics/supernode/01-create-supernode-pool.md
@@ -9,7 +9,7 @@ title: "如何创建超级节点池"
 - **功能名称**: 创建超级节点池
 - **API 版本**: 2018-05-25
 - **适用集群版本**: 所有版本
-- **文档更新时间**: 2026-01-07
+- **文档更新时间**: 2026-05-29
 - **Agent 友好度**: ⭐⭐⭐⭐⭐
 
 ---
@@ -50,8 +50,15 @@ title: "如何创建超级节点池"
 | SubnetIds | 否 | Array | 子网 ID 列表 | ["subnet-xxxxxxxx"] |
 | Labels | 否 | Array | 虚拟节点标签 | 见下方 |
 | Taints | 否 | Array | 虚拟节点污点 | 见下方 |
+| VirtualNodes | 否 | Array | 超级节点列表，元素为 VirtualNodeSpec | 见下方 |
 | DeletionProtection | 否 | Boolean | 删除保护开关 | false |
 | OS | 否 | String | 节点池操作系统 | linux |
+| SubnetAllocationPolicy | 否 | Object | 子网资源分配策略，精确控制各子网资源比例 | 见下方 |
+| AgentPlugin | 否 | Object | AgentPlugin 安装配置；传入即表示需要安装，即使是空对象 `{}` | 见下方 |
+
+:::note
+`SubnetAllocationPolicy` 与 `SubnetIds`、`VirtualNodes` 互斥，不要在同一个创建请求中同时传入。
+:::
 
 **Labels 结构**:
 
@@ -81,6 +88,69 @@ title: "如何创建超级节点池"
       "Effect": "NoSchedule"
     }
   ]
+}
+```
+
+**VirtualNodes 结构**:
+
+```json
+{
+  "VirtualNodes": [
+    {
+      "DisplayName": "vk-node-a",
+      "SubnetId": "subnet-xxxxxxxx"
+    }
+  ]
+}
+```
+
+可选字段:
+
+- `Tags`: 腾讯云标签。
+- `Quota`: 按量配额。
+
+**SubnetAllocationPolicy 结构**:
+
+```json
+{
+  "SubnetAllocationPolicy": {
+    "Allocations": [
+      {
+        "SubnetId": "subnet-xxxxxxx1",
+        "Ratio": 60
+      },
+      {
+        "SubnetId": "subnet-xxxxxxx2",
+        "Ratio": 40
+      }
+    ]
+  }
+}
+```
+
+`Allocations` 不能为空；每个 `SubnetId` 不能重复；`Ratio` 需要为正整数，且所有 `Ratio` 之和必须等于 100。
+
+**AgentPlugin 结构**:
+
+```json
+{
+  "AgentPlugin": {}
+}
+```
+
+如需连接外部 PostgreSQL，可传入以下字段。不要在文档、脚本或仓库配置中写入真实密码。
+
+```json
+{
+  "AgentPlugin": {
+    "ChartVersion": "1.0.0",
+    "Host": "10.0.1.100",
+    "Port": 5432,
+    "Username": "dbuser",
+    "Password": "dbpass",
+    "SSLMode": "require",
+    "ServiceDomain": "agentplugin.example.com"
+  }
 }
 ```
 
@@ -235,6 +305,8 @@ tccli tke DescribeClusterVirtualNodePools \
 |--------|---------|------|---------|
 | InvalidParameter.SubnetNotExist | 子网不存在 | SubnetId 不存在或无权限 | 检查子网 ID 是否正确 |
 | InvalidParameter.SubnetInvalidError | 子网配置错误 | 子网配置不合法 | 确认子网在正确的 VPC 中 |
+| InvalidParameter.SubnetAllocationPolicyConflict | 子网分配策略冲突 | `SubnetAllocationPolicy` 与 `SubnetIds` 或 `VirtualNodes` 同时传入 | 仅保留一种子网配置方式 |
+| InvalidParameter.SubnetAllocationPolicyInvalid | 子网分配策略校验失败 | `Allocations` 为空、SubnetId 重复、Ratio 非正整数或总和不等于 100 | 检查 `Allocations` 列表和 `Ratio` 配置 |
 | ResourceInUse.SubnetAlreadyExist | 子网已被使用 | 子网已被其他节点池占用 | 选择其他可用子网 |
 | ResourceUnavailable.ClusterState | 集群状态异常 | 集群状态不支持操作 | 等待集群状态恢复正常 |
 | UnauthorizedOperation.CamNoAuth | 无权限 | CAM 权限不足 | 申请 TKE 相关权限 |
@@ -275,6 +347,46 @@ kubectl logs -n kube-system -l app=virtual-kubelet
 ```
 
 **说明**: 多子网配置可实现跨可用区的容灾能力
+
+### 配置子网资源分配策略
+
+```json
+{
+  "SubnetAllocationPolicy": {
+    "Allocations": [
+      {
+        "SubnetId": "subnet-xxxxxxx1",
+        "Ratio": 50
+      },
+      {
+        "SubnetId": "subnet-xxxxxxx2",
+        "Ratio": 50
+      }
+    ]
+  }
+}
+```
+
+**说明**: 使用 `SubnetAllocationPolicy` 时，不要同时传入 `SubnetIds` 或 `VirtualNodes`。所有 `Ratio` 之和必须等于 100。
+
+### 配置超级节点列表
+
+```json
+{
+  "VirtualNodes": [
+    {
+      "DisplayName": "vk-node-a",
+      "SubnetId": "subnet-xxxxxxx1"
+    },
+    {
+      "DisplayName": "vk-node-b",
+      "SubnetId": "subnet-xxxxxxx2"
+    }
+  ]
+}
+```
+
+**说明**: `DisplayName` 和 `SubnetId` 为必填字段；`DisplayName` 建议不超过 20 个字符。
 
 ### 配置节点标签和污点
 
@@ -390,5 +502,5 @@ kubectl logs -n kube-system -l app=virtual-kubelet
 ---
 
 **文档版本**: v1.0  
-**最后更新**: 2026-01-07  
+**最后更新**: 2026-05-29
 **维护者**: TKE Documentation Team


### PR DESCRIPTION
## Doc Change Report

Source issue: TKE-33

canonical_doc_path: `src/content/docs/basics/supernode/01-create-supernode-pool.md`
operation_id: `tke.supernode.virtual_node_pool.create`

### Scope
- Updated `src/content/docs/basics/supernode/01-create-supernode-pool.md` only.
- Refreshed the documented API update date to `2026-05-29`.
- Added current optional CreateClusterVirtualNodePool fields: `VirtualNodes`, `SubnetAllocationPolicy`, and `AgentPlugin`.
- Added copyable JSON examples, mutual-exclusion guidance for `SubnetAllocationPolicy`, and the newly documented subnet-allocation error codes.

### Fact Sources
- https://cloud.tencent.com/document/api/457/85354
  - Official page timestamp: `2026-05-29 03:06:06`
  - Reason used: authoritative CreateClusterVirtualNodePool input parameters and error codes.
- https://cloud.tencent.com/document/api/457/31866
  - Official page timestamp: `2026-06-15 01:58:31`
  - Reason used: authoritative data structures for `AgentPluginConfig`, `SubnetAllocationPolicy`, `SubnetAllocation`, and `VirtualNodeSpec`.

### Static Compile
- `node --test test/*.test.mjs`: 10/10 passed.
- `node` code-fence check for `src/content/docs/basics/supernode/01-create-supernode-pool.md`: 22 code fences checked; JSON fences parsed.
- `git diff --check`: passed.
- MkDocs strict build: skipped because this repo has no `mkdocs.yml` or `mkdocs.yaml`.

### Dry Run Compile
- `python3 -m py_compile cookbook/cluster/create_cluster.py cookbook/cluster/delete_cluster.py cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py cookbook/supernode/deploy_gpu_pod.py cookbook/workload/deploy_nginx.py`: passed.
- `npm run build`: passed; Astro built 184 pages.

### Live Verify
- Not required. This is a documentation-only API field refresh and no real Tencent Cloud/TKE resources were created, changed, or deleted.

### Remaining Human Confirmation
- None.
