### PR TITLE
TKE-49: fix cookbook README doc links

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -127,9 +127,9 @@ python3 supernode/deploy_gpu_pod.py \
 
 | 脚本 | 语言 | 功能 | 文档链接 |
 |------|------|------|---------|
-| `create_cluster.py` | Python | 创建 TKE 集群 | [docs](../docs/basics/cluster/01-create-cluster.md) |
-| `delete_cluster.py` | Python | 删除 TKE 集群，默认 dry-run | [docs](../docs/basics/cluster/02-delete-cluster.md) |
-| `describe_clusters.py` | Python | 查询 TKE 集群列表和详情 | [docs](../docs/basics/cluster/04-describe-clusters.md) |
+| `create_cluster.py` | Python | 创建 TKE 集群 | [docs](../src/content/docs/basics/cluster/01-create-cluster.md) |
+| `delete_cluster.py` | Python | 删除 TKE 集群，默认 dry-run | [docs](../src/content/docs/basics/cluster/02-delete-cluster.md) |
+| `describe_clusters.py` | Python | 查询 TKE 集群列表和详情 | [docs](../src/content/docs/basics/cluster/04-describe-clusters.md) |
 
 ### 工作负载 (workload/)
 
@@ -141,7 +141,7 @@ python3 supernode/deploy_gpu_pod.py \
 
 | 脚本 | 语言 | 功能 | 文档链接 |
 |------|------|------|---------|
-| `deploy_gpu_pod.py` | Python | 在超级节点上部署 GPU Pod | [docs](../docs/basics/supernode/02-create-supernode.md) |
+| `deploy_gpu_pod.py` | Python | 在超级节点上部署 GPU Pod | [docs](../src/content/docs/basics/supernode/02-create-supernode.md) |
 
 ---
 


### PR DESCRIPTION
Health Check deterministic fix from TKE-49.

## Changes
- Fixed four `cookbook/README.md` documentation links that pointed at non-existent `../docs/...` paths.
- Updated those links to the actual Astro source paths under `../src/content/docs/...`.

## Verification
- `npm run build`
- `find cookbook -name '*.py' -print0 | xargs -0 -r python3 -m py_compile`\n- `git diff --check`\n- `node --test test/navigation.test.mjs test/cookbooks.test.mjs test/create-cluster-autoupgrade.test.mjs`\n\n## Follow-up\n- TKE-50 tracks the remaining `cookbook/supernode/README.md` stale GPU best-practice URL and missing `LICENSE` target, which need Doc Change/human confirmation rather than sweep-agent rewriting.