### PR TITLE
TKE-50: fix supernode cookbook stale links

### DIFF
--- a/cookbook/supernode/README.md
+++ b/cookbook/supernode/README.md
@@ -6,7 +6,7 @@
 
 本目录提供在 TKE 超级节点上部署 GPU Pod 的完整示例，包括 Python 脚本和 YAML 配置文件。
 
-**文档链接**: [GPU Pod 最佳实践](https://tke-workshop.github.io/ai-ml/04-gpu-pod-best-practices/)
+**文档链接**: [超级节点 GPU](https://tke-workshop.github.io/ai-ml/training/supernode-gpu/)
 
 ---
 
@@ -272,7 +272,7 @@ kubectl get pods -l scenario=batch-inference
 | **L20** | 48GB | 12.7 | 高端图形工作负载 | 48核/192GiB |
 | **L40** | 48GB | 12.7 | 高端图形工作负载 | 48核/192GiB |
 
-完整规格表请参考: [GPU Pod 最佳实践文档](https://tke-workshop.github.io/ai-ml/04-gpu-pod-best-practices/#支持的-gpu-规格)
+更多超级节点 GPU 说明请参考: [超级节点 GPU 文档](https://tke-workshop.github.io/ai-ml/training/supernode-gpu/)
 
 ---
 
@@ -370,7 +370,7 @@ kubectl describe pod <pod-name> | grep -i cache
 
 ## 📚 相关文档
 
-- [GPU Pod 最佳实践](https://tke-workshop.github.io/ai-ml/04-gpu-pod-best-practices/)
+- [超级节点 GPU](https://tke-workshop.github.io/ai-ml/training/supernode-gpu/)
 - [创建超级节点池](https://tke-workshop.github.io/basics/supernode/01-create-supernode-pool/)
 - [创建按量超级节点](https://tke-workshop.github.io/basics/supernode/02-create-supernode/)
 - [镜像缓存文档](https://cloud.tencent.com/document/product/457/65908)
@@ -385,7 +385,7 @@ kubectl describe pod <pod-name> | grep -i cache
 
 ## 📄 许可证
 
-[Apache License 2.0](../../LICENSE)
+Apache License 2.0
 
 ---
 

--- a/cookbook/supernode/deploy_gpu_pod.py
+++ b/cookbook/supernode/deploy_gpu_pod.py
@@ -4,7 +4,7 @@
 
 功能: 在 TKE 超级节点上创建 GPU Pod，支持自动匹配和手动指定 GPU 类型
 使用方法: python3 deploy_gpu_pod.py --help
-文档链接: https://tke-workshop.github.io/ai-ml/04-gpu-pod-best-practices/
+文档链接: https://tke-workshop.github.io/ai-ml/training/supernode-gpu/
 """
 
 import argparse

--- a/cookbook/supernode/gpu_pod_examples.yaml
+++ b/cookbook/supernode/gpu_pod_examples.yaml
@@ -1,5 +1,5 @@
 # GPU Pod 配置示例集合
-# 文档: https://tke-workshop.github.io/ai-ml/04-gpu-pod-best-practices/
+# 文档: https://tke-workshop.github.io/ai-ml/training/supernode-gpu/
 
 ---
 # 示例 1: 基础 GPU Pod（自动匹配 - 推荐）


### PR DESCRIPTION
## Summary

Fixes stale supernode GPU cookbook links reported by TKE-50.

## Changes

- Updated `cookbook/supernode/README.md` GPU documentation references from the removed `/ai-ml/04-gpu-pod-best-practices/` route to the current `/ai-ml/training/supernode-gpu/` route.
- Removed the stale `#支持的-gpu-规格` anchor reference because the current target page has no matching section; the local README table remains the source for the listed cookbook specs.
- Converted the broken `../../LICENSE` link in `cookbook/supernode/README.md` to plain `Apache License 2.0`, matching the root cookbook README license text without linking to a missing file.
- Updated directly related cookbook references in `cookbook/supernode/deploy_gpu_pod.py` and `cookbook/supernode/gpu_pod_examples.yaml`.

## Doc Change Report

- Source issue: TKE-50 (`a177fdf6-b9fd-4dc6-990c-bc267c3baea3`)
- canonical_doc_path: `cookbook/supernode/README.md`
- operation_id: `tke.supernode.gpu_pod.deploy`
- Modified scope: `cookbook/supernode/README.md`, `cookbook/supernode/deploy_gpu_pod.py`, `cookbook/supernode/gpu_pod_examples.yaml`
- Fact sources:
  - `src/content/docs/ai-ml/training/supernode-gpu.md` (repo source; no page update timestamp in file): confirms current generated route source and title `超级节点 GPU`.
  - `astro.config.mjs` (repo source; no page update timestamp): confirms Starlight autogenerates the `ai-ml` docs tree.
  - `src/data/cookbooks.js` (repo source; no page update timestamp): already references `/ai-ml/training/supernode-gpu/` as the supernode GPU link.
  - `cookbook/README.md` (repo source; last updated `2026-01-07` in file): existing cookbook license section states `Apache License 2.0` without a root `LICENSE` link.
  - `npm run build` output: confirms `dist/ai-ml/training/supernode-gpu/index.html` is generated.
- Static Compile:
  - `find cookbook -name '*.py' -print0 | xargs -0 python3 -m py_compile` passed.
  - `ruby -e 'require "yaml"; YAML.load_stream(File.read("cookbook/supernode/gpu_pod_examples.yaml"))'` passed.
  - `git diff --check` passed.
  - Scoped stale-link search for `04-gpu-pod-best-practices`, `../../LICENSE`, and `支持的-gpu-规格` in `cookbook/supernode` found no matches.
- Dry Run Compile:
  - `npm run build` passed.
  - Generated route existence check for `dist/ai-ml/training/supernode-gpu/index.html` passed.
  - `mkdocs build --strict` skipped: repository has no `mkdocs.yml` or `mkdocs.yaml`.
- Live Verify: not required; this change only updates documentation links/comments and does not create, delete, or modify Tencent Cloud/TKE resources.
- Remaining human confirmation: none for this scoped link fix. A separate legal/content decision is still needed if the repository should add a root `LICENSE` file instead of leaving cookbook license text unlinked.
