### PR TITLE
TKE-54: fix cookbook README local links

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -127,9 +127,9 @@ python3 supernode/deploy_gpu_pod.py \
 
 | 脚本 | 语言 | 功能 | 文档链接 |
 |------|------|------|---------|
-| `create_cluster.py` | Python | 创建 TKE 集群 | [docs](../docs/basics/cluster/01-create-cluster.md) |
-| `delete_cluster.py` | Python | 删除 TKE 集群，默认 dry-run | [docs](../docs/basics/cluster/02-delete-cluster.md) |
-| `describe_clusters.py` | Python | 查询 TKE 集群列表和详情 | [docs](../docs/basics/cluster/04-describe-clusters.md) |
+| `create_cluster.py` | Python | 创建 TKE 集群 | [docs](../src/content/docs/basics/cluster/01-create-cluster.md) |
+| `delete_cluster.py` | Python | 删除 TKE 集群，默认 dry-run | [docs](../src/content/docs/basics/cluster/02-delete-cluster.md) |
+| `describe_clusters.py` | Python | 查询 TKE 集群列表和详情 | [docs](../src/content/docs/basics/cluster/04-describe-clusters.md) |
 
 ### 工作负载 (workload/)
 
@@ -141,7 +141,7 @@ python3 supernode/deploy_gpu_pod.py \
 
 | 脚本 | 语言 | 功能 | 文档链接 |
 |------|------|------|---------|
-| `deploy_gpu_pod.py` | Python | 在超级节点上部署 GPU Pod | [docs](../docs/basics/supernode/02-create-supernode.md) |
+| `deploy_gpu_pod.py` | Python | 在超级节点上部署 GPU Pod | [docs](../src/content/docs/basics/supernode/02-create-supernode.md) |
 
 ---
 

--- a/cookbook/supernode/README.md
+++ b/cookbook/supernode/README.md
@@ -385,7 +385,7 @@ kubectl describe pod <pod-name> | grep -i cache
 
 ## 📄 许可证
 
-[Apache License 2.0](../../LICENSE)
+Apache License 2.0
 
 ---
 


### PR DESCRIPTION
TKE-54 health check follow-up.\n\nSummary:\n- Fix cookbook README links that pointed at a non-existent docs/ tree.\n- Replace a local LICENSE link that pointed at a missing repository file with plain license text.\n\nVerification:\n- npm run build\n- node --test test/*.mjs\n- python3 -m py_compile cookbook/cluster/delete_cluster.py cookbook/cluster/create_cluster.py cookbook/cluster/describe_clusters.py cookbook/common/auth.py cookbook/common/logger.py cookbook/workload/deploy_nginx.py cookbook/supernode/deploy_gpu_pod.py\n- git diff --check\n- local sidebar/link existence scanner: 111 sidebar slugs, 316 local targets, 0 missing